### PR TITLE
Support leading zero representation for 24h clock

### DIFF
--- a/movement/movement.h
+++ b/movement/movement.h
@@ -60,9 +60,10 @@ typedef union {
         // time-oriented complication like a sunrise/sunset timer, and a simple locale preference could tell an
         // altimeter to display feet or meters as easily as it tells a thermometer to display degrees in F or C.
         bool clock_mode_24h : 1;            // indicates whether clock should use 12 or 24 hour mode.
+        bool clock_24h_leading_zero : 1;    // indicates whether clock should leading zero to indicate 24 hour mode.
         bool use_imperial_units : 1;        // indicates whether to use metric units (the default) or imperial.
         bool alarm_enabled : 1;             // indicates whether there is at least one alarm enabled.
-        uint8_t reserved : 6;               // room for more preferences if needed.
+        uint8_t reserved : 5;               // room for more preferences if needed.
     } bit;
     uint32_t reg;
 } movement_settings_t;

--- a/movement/watch_faces/clock/simple_clock_face.c
+++ b/movement/watch_faces/clock/simple_clock_face.c
@@ -51,7 +51,7 @@ void simple_clock_face_activate(movement_settings_t *settings, void *context) {
 
     if (watch_tick_animation_is_running()) watch_stop_tick_animation();
 
-    if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+    if (settings->bit.clock_mode_24h && !settings->bit.clock_24h_leading_zero) watch_set_indicator(WATCH_INDICATOR_24H);
 
     // handle chime indicator
     if (state->signal_enabled) watch_set_indicator(WATCH_INDICATOR_BELL);
@@ -117,11 +117,20 @@ bool simple_clock_face_loop(movement_event_t event, movement_settings_t *setting
                     if (date_time.unit.hour == 0) date_time.unit.hour = 12;
                 }
                 pos = 0;
+                const char* fmt;
                 if (event.event_type == EVENT_LOW_ENERGY_UPDATE) {
                     if (!watch_tick_animation_is_running()) watch_start_tick_animation(500);
-                    sprintf(buf, "%s%2d%2d%02d  ", watch_utility_get_weekday(date_time), date_time.unit.day, date_time.unit.hour, date_time.unit.minute);
+                    if (settings->bit.clock_mode_24h && settings->bit.clock_24h_leading_zero)
+                        fmt = "%s%2d%02d%02d  ";
+                    else
+                        fmt = "%s%2d%2d%02d  ";
+                    sprintf(buf, fmt, watch_utility_get_weekday(date_time), date_time.unit.day, date_time.unit.hour, date_time.unit.minute);
                 } else {
-                    sprintf(buf, "%s%2d%2d%02d%02d", watch_utility_get_weekday(date_time), date_time.unit.day, date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
+                    if (settings->bit.clock_mode_24h && settings->bit.clock_24h_leading_zero)
+                        fmt = "%s%2d%02d%02d%02d";
+                    else
+                        fmt = "%s%2d%2d%02d%02d";
+                    sprintf(buf, fmt, watch_utility_get_weekday(date_time), date_time.unit.day, date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
                 }
             }
             watch_display_string(buf, pos);

--- a/movement/watch_faces/clock/world_clock_face.c
+++ b/movement/watch_faces/clock/world_clock_face.c
@@ -60,7 +60,7 @@ static bool world_clock_face_do_display_mode(movement_event_t event, movement_se
     watch_date_time date_time;
     switch (event.event_type) {
         case EVENT_ACTIVATE:
-            if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+            if (settings->bit.clock_mode_24h && !settings->bit.clock_24h_leading_zero) watch_set_indicator(WATCH_INDICATOR_24H);
             watch_set_colon();
             state->previous_date_time = 0xFFFFFFFF;
             // fall through
@@ -93,16 +93,25 @@ static bool world_clock_face_do_display_mode(movement_event_t event, movement_se
                     if (date_time.unit.hour == 0) date_time.unit.hour = 12;
                 }
                 pos = 0;
+                const char* fmt;
                 if (event.event_type == EVENT_LOW_ENERGY_UPDATE) {
                     if (!watch_tick_animation_is_running()) watch_start_tick_animation(500);
-                    sprintf(buf, "%c%c%2d%2d%02d  ",
+                    if (settings->bit.clock_mode_24h && settings->bit.clock_24h_leading_zero)
+                        fmt = "%c%c%2d%02d%02d  ";
+                    else
+                        fmt = "%c%c%2d%2d%02d  ";
+                    sprintf(buf, fmt,
                         movement_valid_position_0_chars[state->settings.bit.char_0],
                         movement_valid_position_1_chars[state->settings.bit.char_1],
                         date_time.unit.day,
                         date_time.unit.hour,
                         date_time.unit.minute);
                 } else {
-                    sprintf(buf, "%c%c%2d%2d%02d%02d",
+                    if (settings->bit.clock_mode_24h && settings->bit.clock_24h_leading_zero)
+                        fmt = "%c%c%2d%02d%02d%02d";
+                    else
+                        fmt = "%c%c%2d%2d%02d%02d";
+                    sprintf(buf, fmt,
                         movement_valid_position_0_chars[state->settings.bit.char_0],
                         movement_valid_position_1_chars[state->settings.bit.char_1],
                         date_time.unit.day,

--- a/movement/watch_faces/complication/alarm_face.c
+++ b/movement/watch_faces/complication/alarm_face.c
@@ -109,7 +109,12 @@ static void _alarm_face_draw(movement_settings_t *settings, alarm_state_t *state
         }
         if (h == 0) h = 12;
     }
-    sprintf(buf, "%c%c%2d%2d%02d  ",
+    const char *fmt;
+    if (settings->bit.clock_mode_24h && settings->bit.clock_24h_leading_zero)
+        fmt = "%c%c%2d%02d%02d  ";
+    else
+        fmt = "%c%c%2d%2d%02d  ";
+    sprintf(buf, fmt,
         _dow_strings[i][0], _dow_strings[i][1],
         (state->alarm_idx + 1),
         h,

--- a/movement/watch_faces/complication/sunrise_sunset_face.c
+++ b/movement/watch_faces/complication/sunrise_sunset_face.c
@@ -85,7 +85,7 @@ static void _sunrise_sunset_face_update(movement_settings_t *settings, sunrise_s
         }
 
         watch_set_colon();
-        if (settings->bit.clock_mode_24h) watch_set_indicator(WATCH_INDICATOR_24H);
+        if (settings->bit.clock_mode_24h && !settings->bit.clock_24h_leading_zero) watch_set_indicator(WATCH_INDICATOR_24H);
 
         rise += hours_from_utc;
         set += hours_from_utc;
@@ -109,7 +109,12 @@ static void _sunrise_sunset_face_update(movement_settings_t *settings, sunrise_s
                     if (watch_utility_convert_to_12_hour(&scratch_time)) watch_set_indicator(WATCH_INDICATOR_PM);
                     else watch_clear_indicator(WATCH_INDICATOR_PM);
                 }
-                sprintf(buf, "rI%2d%2d%02d  ", scratch_time.unit.day, scratch_time.unit.hour, scratch_time.unit.minute);
+                const char* fmt;
+                if (settings->bit.clock_mode_24h && settings->bit.clock_24h_leading_zero)
+                    fmt = "rI%2d%02d%02d  ";
+                else
+                    fmt = "rI%2d%2d%02d  ";
+                sprintf(buf, fmt, scratch_time.unit.day, scratch_time.unit.hour, scratch_time.unit.minute);
                 watch_display_string(buf, 0);
                 return;
             } else {
@@ -136,7 +141,13 @@ static void _sunrise_sunset_face_update(movement_settings_t *settings, sunrise_s
                     if (watch_utility_convert_to_12_hour(&scratch_time)) watch_set_indicator(WATCH_INDICATOR_PM);
                     else watch_clear_indicator(WATCH_INDICATOR_PM);
                 }
-                sprintf(buf, "SE%2d%2d%02d  ", scratch_time.unit.day, scratch_time.unit.hour, scratch_time.unit.minute);
+                const char* fmt;
+                if (settings->bit.clock_mode_24h && settings->bit.clock_24h_leading_zero) {
+                    fmt = "SE%2d%02d%02d  ";
+                } else {
+                    fmt = "SE%2d%2d%02d  ";
+                }
+                sprintf(buf, fmt, scratch_time.unit.day, scratch_time.unit.hour, scratch_time.unit.minute);
                 watch_display_string(buf, 0);
                 return;
             } else {

--- a/movement/watch_faces/complication/wake_face.c
+++ b/movement/watch_faces/complication/wake_face.c
@@ -50,19 +50,24 @@ void _wake_face_update_display(movement_settings_t *settings, wake_face_state_t 
     uint8_t hour = state->hour;
 
     watch_clear_display();
-    if ( settings->bit.clock_mode_24h )
-        watch_set_indicator(WATCH_INDICATOR_24H);
-    else {
+    if ( !settings->bit.clock_mode_24h ) {
         if ( hour >= 12 )
             watch_set_indicator(WATCH_INDICATOR_PM);
         hour = hour % 12 ? hour % 12 : 12;
+    } else if ( !settings->bit.clock_24h_leading_zero ) {
+        watch_set_indicator(WATCH_INDICATOR_24H);
     }
 
     if ( state->mode )
         watch_set_indicator(WATCH_INDICATOR_BELL);
 
     static char lcdbuf[11];
-    sprintf(lcdbuf, "WA  %2d%02d  ", hour, state->minute);
+    const char* fmt;
+    if ( settings->bit.clock_mode_24h && settings->bit.clock_24h_leading_zero )
+        fmt = "WA  %02d%02d  ";
+    else
+        fmt = "WA  %2d%02d  ";
+    sprintf(lcdbuf, fmt, hour, state->minute);
 
     watch_set_colon();
     watch_display_string(lcdbuf, 0);

--- a/movement/watch_faces/settings/preferences_face.c
+++ b/movement/watch_faces/settings/preferences_face.c
@@ -93,6 +93,14 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
                     break;
             }
             break;
+        case EVENT_ALARM_LONG_PRESS:
+            switch (current_page) {
+                case 0:
+                    if (settings->bit.clock_mode_24h)
+                        settings->bit.clock_24h_leading_zero = !(settings->bit.clock_24h_leading_zero);
+                    break;
+            }
+            break;
         case EVENT_TIMEOUT:
             movement_move_to_face(0);
             break;
@@ -107,8 +115,10 @@ bool preferences_face_loop(movement_event_t event, movement_settings_t *settings
         char buf[8];
         switch (current_page) {
             case 0:
-                if (settings->bit.clock_mode_24h) watch_display_string("24h", 4);
-                else watch_display_string("12h", 4);
+                if (settings->bit.clock_mode_24h) {
+                    if (settings->bit.clock_24h_leading_zero) watch_display_string("024h", 4);
+                    else watch_display_string("24h", 4);
+                } else watch_display_string("12h", 4);
                 break;
             case 1:
                 if (settings->bit.button_should_sound) watch_display_string("y", 9);

--- a/movement/watch_faces/settings/set_time_face.c
+++ b/movement/watch_faces/settings/set_time_face.c
@@ -134,8 +134,14 @@ bool set_time_face_loop(movement_event_t event, movement_settings_t *settings, v
     if (current_page < 3) {
         watch_set_colon();
         if (settings->bit.clock_mode_24h) {
-            watch_set_indicator(WATCH_INDICATOR_24H);
-            sprintf(buf, "%s  %2d%02d%02d", set_time_face_titles[current_page], date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
+            const char* fmt;
+            if (settings->bit.clock_24h_leading_zero)
+                fmt = "%s  %02d%02d%02d";
+            else {
+                fmt = "%s  %2d%02d%02d";
+                watch_set_indicator(WATCH_INDICATOR_24H);
+            }
+            sprintf(buf, fmt, set_time_face_titles[current_page], date_time.unit.hour, date_time.unit.minute, date_time.unit.second);
         } else {
             sprintf(buf, "%s  %2d%02d%02d", set_time_face_titles[current_page], (date_time.unit.hour % 12) ? (date_time.unit.hour % 12) : 12, date_time.unit.minute, date_time.unit.second);
             if (date_time.unit.hour < 12) watch_clear_indicator(WATCH_INDICATOR_PM);


### PR DESCRIPTION
Toggle between default behavior and leading zero with long-press of alarm button on page with 24h setting.